### PR TITLE
Don't exit at first error : print all instead

### DIFF
--- a/pre-receive
+++ b/pre-receive
@@ -1,6 +1,6 @@
 #!/bin/bash
-
 warned=0
+final_ret=0
 
 while read oldrev newrev refname; do
     for puppetmodule in `git diff-tree --no-commit-id --name-only -r $newrev`; do
@@ -13,16 +13,16 @@ while read oldrev newrev refname; do
         git show $newrev:$puppetmodule > $tmpmodule
         case $puppetmodule in
             *.pp ) 
-                puppet parser validate $tmpmodule 2&> $tmperror
+                /var/lib/gems/1.8/bin/puppet parser validate --storeconfigs true $tmpmodule 2&> $tmperror
                 rc=$?
                 if [[ $rc != 0 ]]; then
-                    echo -e "\e[0;31m'puppet parser validate' failed on $puppetmodule - push deniend. Run tests locally and confirm they pass before pushing. \e[0m"
+                    echo -e "\e[0;31m'puppet parser validate' failed on $puppetmodule - push denied. Run tests locally and confirm they pass before pushing. \e[0m"
                     cat $tmperror
                     rm -rf $tmpdir
-                    exit $rc
+                    final_ret=1
                 fi
                 # Check styleguide, but do not error if styleguide does not pass
-                /usr/bin/puppet-lint --fail-on-warnings --no-80chars-check $tmpmodule > $tmperror
+                /var/lib/gems/1.8/bin/puppet-lint --fail-on-warnings --no-80chars-check $tmpmodule > $tmperror
                 rc=$?
                 if [[ $rc != 0 ]]; then
                     if [[ $warned = 0 ]]; then
@@ -45,11 +45,12 @@ while read oldrev newrev refname; do
                     cat $tmperror
                     echo -e "\e[0m"
                     echo -e "\e[0;33m" "Commit accepted, but the above template will not expand properly" "\e[0m"
+                    final_ret=1
                 fi
                 ;;
         esac
         rm -rf $tmpdir
     done
 done
-# Everything went OK so we can exit with a zero
-exit 0
+
+exit $final_ret


### PR DESCRIPTION
Hi,
I think it's more convinient for the user to know of all errors before retrying to push to a server.
