### PR TITLE
Don't exit at first error : print all instead

### DIFF
--- a/pre-receive
+++ b/pre-receive
@@ -19,7 +19,7 @@ while read oldrev newrev refname; do
         git show $newrev:$puppetmodule > $tmpmodule
         case $puppetmodule in
             *.pp ) 
-                /var/lib/gems/1.8/bin/puppet parser validate --storeconfigs true $tmpmodule 2&> $tmperror
+                /var/lib/gems/1.8/bin/puppet parser validate --ignoreimport --storeconfigs true $tmpmodule 2&> $tmperror
                 rc=$?
                 if [[ $rc != 0 ]]; then
                     echo -e "\e[0;31m'puppet parser validate' failed on $puppetmodule - push denied. Run tests locally and confirm they pass before pushing. \e[0m"


### PR DESCRIPTION
Hi,
I think it's more convenient for the user to have all errors at once before retrying to push.
Also fix typo deniend->denied.
