### PR TITLE
Fix issues with spaces in filenames or directories.

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -21,11 +21,11 @@ do
         *.pp )
             # Check puppet manifest syntax
             echo -e "Validate Puppet module: \033[0;32m$puppetmodule\033[0m"
-            puppet parser validate --color=true $git_root/$puppetmodule > $error_msg ;;
+            puppet parser validate --color=true "$git_root/$puppetmodule" > $error_msg ;;
         *.erb )
             # Check ERB template syntax
             echo -e "Validate Puppet template: \033[0;32m$puppetmodule\033[0m"
-            erb -P -x -T '-' $git_root/$puppetmodule | ruby -c 2> $error_msg > /dev/null ;;
+            erb -P -x -T '-' "$git_root/$puppetmodule" | ruby -c 2> $error_msg > /dev/null ;;
     esac
     if [ $? -ne 0 ]
     then
@@ -47,7 +47,7 @@ fi
 if [ `which puppet-lint` ]; then
     for puppetmodule in `git diff --cached --name-only --diff-filter=ACM | grep \.*.pp$`; do
         echo -e "Style check for Puppet module: \033[0;32m$puppetmodule\033[0m"
-        puppet-lint --fail-on-warnings --with-filename --no-80chars-check --no-double_quoted_strings-check $git_root/$puppetmodule
+        puppet-lint --fail-on-warnings --with-filename --no-80chars-check --no-double_quoted_strings-check "$git_root/$puppetmodule"
         RC=$?
         if [ $RC -ne 0 ]; then
             exit $RC


### PR DESCRIPTION
White spaces in file names or directory names caused syntax check to fail without a useful error. This change ensures white spaces are handled correctly.
