### PR TITLE
add support for calling the hook from a symlink

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -6,6 +6,14 @@ RC=0
 
 subhook_root=$git_root/.git/hooks/commit_hooks
 
+hook_dir="$(dirname $0)"
+hook_symlink="$(readlink $0)"
+
+# Figure out where commit hooks are if pre-commit is setup as a symlink
+if [ ! -z "$hook_symlink" ]; then
+  subhook_root="$(dirname $hook_symlink)/commit_hooks"
+fi
+
 for changedfile in `git diff --cached --name-only --diff-filter=ACM`; do
     #check puppet manifest syntax
     if type puppet >/dev/null 2>&1; then


### PR DESCRIPTION
I setup your pre-commit hook as a symlink in my puppet git repo, and got this error:

```
#!/bin/bash
.git/hooks/pre-commit: line 39: /home/gpetras/git/hieradata/.git/hooks/commit_hooks/yaml_syntax_check.sh: No such file or directory
.git/hooks/pre-commit: line 65: /home/gpetras/git/hieradata/.git/hooks/commit_hooks/rspec_puppet_checks.sh: No such file or directory
Error: 2 subhooks failed. Aborting commit.
```

Thought you might be interested in the fix that worked for me.

Thanks for the hooks!

Greg
