### PR TITLE
wrapped $1 variable to handle to handle long paths

### DIFF
--- a/commit_hooks/json_syntax_check.sh
+++ b/commit_hooks/json_syntax_check.sh
@@ -14,7 +14,7 @@ fi
 
 # Check json file syntax
 echo -e "$(tput setaf 6)Checking json syntax for $module_path...$(tput sgr0)"
-ruby -e "require 'json'; JSON.parse(File.read($1))" 2> $error_msg > /dev/null
+ruby -e "require 'json'; JSON.parse(File.read('$1'))" 2> $error_msg > /dev/null
 if [ $? -ne 0 ]; then
     cat $error_msg | sed -e "s/^/$(tput setaf 1)/" -e "s/$/$(tput sgr0)/"
     syntax_errors=`expr $syntax_errors + 1`


### PR DESCRIPTION
[jsohl@jsohl-centos6 puppet]$ .git/hooks/pre-commit
Checking json syntax for modint/stdlib/checksums.json...
-e:1: undefined local variable or method `modint' for main:Object (NameError)
Error: json syntax error in modint/stdlib/checksums.json (see above)
Error: 1 syntax error(s) found in json file.  Commit will be aborted.
