### PR TITLE
fix remote: fatal: bad object 0000000000000000000000000000000000000000

### DIFF
--- a/pre-receive
+++ b/pre-receive
@@ -23,6 +23,13 @@ export TERM
 
 while read oldrev newrev refname; do
     git archive $newrev | tar x -C ${tmptree}
+
+		# for a new branch oldrev is 0{40}, set newrev to branch name and oldrev to parent branch
+		if [[ $oldrev == "0000000000000000000000000000000000000000" ]]; then
+						newrev=`git rev-parse --abbrev-ref HEAD`
+						oldrev=`git show-branch | ack '\*' | ack -v "$newrev" | head -n1 | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//'`
+		fi
+
     for changedfile in $(git diff --name-only $oldrev $newrev --diff-filter=ACM); do
         tmpmodule="$tmptree/$changedfile"
         #check puppet manifest syntax


### PR DESCRIPTION
I noticed on a new branch the pre-receive hook would fail.  I figured this was because on a new branch oldref is 0{40}. If a new branch is detected it sets newref to the branch name and oldref to the branche's parent.