### PR TITLE
Setting $HOME for user

### DIFF
--- a/pre-receive
+++ b/pre-receive
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Puppet attempts to source ~/.puppet and will error if $HOME is not set
+if [ -z $HOME ]
+then
+  export HOME=$(grep "${USER}:" /etc/passwd | awk -F ':' '{print $6}')
+fi
+
 failures=0
 RC=0
 


### PR DESCRIPTION
When using the pre-receive hook with GitLab 7.6.2 the hook fails because when push is done via ssh $HOME is not set for git user. This was brought up in issue #12 but no fix was committed.

I made use of $USER here so hopefully this will handle other variations of this problem. If there is a better way to do this let me know and I can work on it.

Thanks,

Example failure
```
12:44 $ git push
Connected to git-1
This system is managed by puppet.
Counting objects: 10, done.
Delta compression using up to 2 threads.
Compressing objects: 100% (6/6), done.
Writing objects: 100% (6/6), 783 bytes, done.
Total 6 (delta 3), reused 0 (delta 0)
remote: puppet-lint not installed. Skipping puppet-lint tests...
remote: Checking puppet manifest syntax for manifests/controller.pp...
remote: Error: Could not initialize global default settings: couldn't find HOME environment -- expanding `~/.puppet'
remote: Error: puppet syntax error in manifests/controller.pp (see above)
remote: Error: 1 syntax error(s) found in puppet manifests. Commit will be aborted.
remote: puppet-lint not installed. Skipping puppet-lint tests...
remote: Checking puppet manifest syntax for manifests/datacenter.pp...
remote: Error: Could not initialize global default settings: couldn't find HOME environment -- expanding `~/.puppet'
remote: Error: puppet syntax error in manifests/datacenter.pp (see above)
remote: Error: 1 syntax error(s) found in puppet manifests. Commit will be aborted.
remote: puppet-lint not installed. Skipping puppet-lint tests...
remote: Error: 2 subhooks failed. Declining push.
```

Tested that hook still works with change.
```
✔ ~/workspace/puppet-modules/ap_c3 [hooktest|●1]
13:53 $ git ci -m 'file with typos'
[hooktest 2122500] file with typos
 1 files changed, 3 insertions(+), 0 deletions(-)
 create mode 100644 manifests/test.pp
✔ ~/workspace/puppet-modules/ap_c3 [hooktest ↑·1|✔]
13:53 $ git push origin hooktest
Connected to git-1
This system is managed by puppet.
Counting objects: 6, done.
Delta compression using up to 2 threads.
Compressing objects: 100% (3/3), done.
Writing objects: 100% (4/4), 369 bytes, done.
Total 4 (delta 2), reused 0 (delta 0)
remote: Checking puppet manifest syntax for manifests/test.pp...
remote: Error: Could not parse for environment production: Unclosed quote after '' in ' :
remote:  ensure => present
remote: }
remote: ' at manifests/test.pp:1
remote: Error: puppet syntax error in manifests/test.pp (see above)
remote: Error: 1 syntax error(s) found in puppet manifests. Commit will be aborted.
remote: puppet-lint not installed. Skipping puppet-lint tests...
remote: Error: 1 subhooks failed. Declining push.
To git@git-1:puppet-modules/ap_c3.git
 ! [remote rejected] hooktest -> hooktest (pre-receive hook declined)
```