### PR TITLE
Ensure TERM is set to avoid tput warnings

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+TERM=${TERM:-unknown}; export TERM
+
 git_root=`git rev-parse --show-toplevel`
 failures=0
 RC=0


### PR DESCRIPTION
At least on a Mac using Tower git client, if TERM was not set, tput dumped out warnings.  This suppresses error messages in third party applications that trigger this git hook.