### PR TITLE
Call json_syntax_check on json files in pre-receive

### DIFF
--- a/pre-receive
+++ b/pre-receive
@@ -73,6 +73,15 @@ while read oldrev newrev refname; do
                     failures=`expr $failures + 1`
                 fi
             fi
+            
+            #check hiera data (json) syntax
+            if [ $(echo $changedfile | grep -q '\.*.json$'; echo $?) -eq 0 ]; then 
+                ${subhook_root}/json_syntax_check.sh $tmpmodule "${tmptree}/"
+                RC=$?
+                if [ "$RC" -ne 0 ]; then
+                    failures=`expr $failures + 1`
+                fi
+            fi
         else
             echo "ruby not installed. Skipping erb/yaml checks..."
         fi


### PR DESCRIPTION
Hi,

I use your pre-receive and use JSON files in my heiradata folder which are maintained by a git repository.
I added a call to json_syntax_check in the pre-receive hook.

Take a look.

Thanks