### PR TITLE
check if r10k is installed first

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -109,12 +109,16 @@ else
 fi
 
 #r10k puppetfile syntax check
-if [ $changedfile = "Puppetfile" ]; then
-	${subhook_root}/r10k_syntax_check.sh
-	RC=$?
-	if [ "$RC" -ne 0 ]; then
-        	failures=`expr $failures + 1`
-	fi
+if which r10k >/dev/null 2>&1; then
+  if [ $changedfile = "Puppetfile" ]; then
+        ${subhook_root}/r10k_syntax_check.sh
+        RC=$?
+        if [ "$RC" -ne 0 ]; then
+                failures=`expr $failures + 1`
+        fi
+  fi
+else
+    echo "r10k not installed. Skipping r10k Puppetfile test..."
 fi
 
 #summary


### PR DESCRIPTION
Need to see if r10k is installed before trying to run the check.

After modifying Puppetfile:
```
~/workspace/puppet [whitespace|●1⚑ 1]
17:18 $ git ci -m 'fixed whitespace in tempate'
r10k not installed. Skipping r10k Puppetfile test...
[whitespace e17f848] fixed whitespace in tempate
 1 files changed, 1 insertions(+), 1 deletions(-)
```

Thanks