### PR TITLE
locating commit_hooks

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -14,6 +14,8 @@ hook_symlink="$(readlink $0)"
 # Figure out where commit hooks are if pre-commit is setup as a symlink
 if [ ! -z "$hook_symlink" ] && ! [[ "$hook_symlink" == ../* ]]; then
   subhook_root="$(dirname $hook_symlink)/commit_hooks"
+else
+  subhook_root="${hook_dir}/commit_hooks"
 fi
 
 # If using submodules, we need to read proper subhook root

--- a/pre-commit
+++ b/pre-commit
@@ -6,15 +6,15 @@ git_root=`git rev-parse --show-toplevel`
 failures=0
 RC=0
 
-subhook_root=$git_root/.git/hooks/commit_hooks
-
 hook_dir="$(dirname $0)"
 hook_symlink="$(readlink $0)"
 
-# Figure out where commit hooks are if pre-commit is setup as a symlink
+# Figure out where commit hooks are
 if [ ! -z "$hook_symlink" ] && ! [[ "$hook_symlink" == ../* ]]; then
+  #pre-commit is setup as a symlink
   subhook_root="$(dirname $hook_symlink)/commit_hooks"
 else
+  #commit_hooks should be with pre-commit
   subhook_root="${hook_dir}/commit_hooks"
 fi
 


### PR DESCRIPTION
This change allows for the pre-commit hook to reside outside of .git/hooks and be called from a "wrapper" pre-commit. In my repos I wrote a custom pre-commit that checks general things, such as trailing whitespace, and locking branches. I didn't change the other hooks, eg, pre-recieve, etc. because I haven't used them so can't confirm if it's relevent.
Thanks!

Example:
```bash
#!/bin/bash
# lock branches for committing. We use feature branches and merge via GitLab merge requests.
git_root=`git rev-parse --show-toplevel`
refname=$(git rev-parse --abbrev-ref HEAD)

# space separated list of locked branches
locked="master default production preproduction"

for b in $locked; do
  if [[ "$refname" = "$b" ]]
    then
      echo "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
      echo "You cannot commit to ${refname}. It's locked"
      echo "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
      exit 1
  fi
done

# Run checks
failed=0

#check for trailing whitespace
for changedfile in `git diff --cached --name-only --diff-filter=ACM`; do
echo -e "$(tput setaf 6)Checking for trailing whitespace in $changedfile ...$(tput sgr0)"
grep -n --color=always '\ $' ${git_root}/${changedfile}
  RC=$?
  if [ "$RC" -eq 0 ]; then
    echo -e "$(tput setaf 1)Trailing whitespace found!$(tput sgr0)"
    failed=`expr $failed + 1`
    exit 1
  fi
done

# Call puppet pre-commit hooks if they are in home directory
if [ -e ~/.puppet-git-hooks/pre-commit ]; then
~/.puppet-git-hooks/pre-commit
RC=$?
if [ "$RC" -ne 0 ]; then
    failed=`expr $failed + 1`
  fi
fi

if [ "$failed" -ne 0 ]; then
    echo -e "$(tput setaf 1)Error: Hooks failed. Aborting commit.$(tput sgr0)"
    exit 1
fi
exit 0
```