### PR TITLE
Make puppet-lint check optional

### DIFF
--- a/commit_hooks/config.cfg
+++ b/commit_hooks/config.cfg
@@ -1,0 +1,1 @@
+CHECK_PUPPET_LINT=true # true or false

--- a/commit_hooks/config.cfg
+++ b/commit_hooks/config.cfg
@@ -1,1 +1,1 @@
-CHECK_PUPPET_LINT=true # true or false
+CHECK_PUPPET_LINT="enabled" # enabled, permissive or disabled (permissive runs but return code is ignored)

--- a/commit_hooks/puppet_lint_checks.sh
+++ b/commit_hooks/puppet_lint_checks.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-# This script expects $1 to be passed and for $1 to be the filesystem location
+# $1 is the puppet-lint mode (enabled, permissive, disabled)
+# This script expects $2 to be passed and for $2 to be the filesystem location
 # to a puppet manifest file for which it will run style guide checks against.
 
-manifest_path="$1"
-module_dir="$2"
+CHECK_PUPPET_LINT="$1"
+manifest_path="$2"
+module_dir="$3"
 
 syntax_errors=0
 error_msg=$(mktemp /tmp/error_msg_puppet-lint.XXXXX)
@@ -23,7 +25,7 @@ echo -e "$(tput setaf 6)Checking puppet style guide compliance for $manifest_nam
 # If a file named .puppet-lint.rc exists at the base of the repo then use it to
 # enable or disable checks.
 puppet_lint_cmd="puppet-lint --fail-on-warnings --with-filename"
-puppet_lint_rcfile="${2}.puppet-lint.rc"
+puppet_lint_rcfile="${3}.puppet-lint.rc"
 if [ -f $puppet_lint_rcfile ]; then
     echo -e "$(tput setaf 6)Applying custom config from .puppet-lint.rc$(tput sgr0)"
     puppet_lint_cmd="$puppet_lint_cmd --config $puppet_lint_rcfile"
@@ -31,7 +33,7 @@ else
     puppet_lint_cmd="$puppet_lint_cmd --no-80chars-check"
 fi
 
-$puppet_lint_cmd $1 2>&1 > $error_msg
+$puppet_lint_cmd $2 2>&1 > $error_msg
 RC=$?
 if [ $RC -ne 0 ]; then
     syntax_errors=$(expr $syntax_errors + 1)
@@ -41,10 +43,14 @@ fi
 rm -f $error_msg
 
 if [ $syntax_errors -ne 0 ]; then
-    echo -e "Error: $syntax_errors styleguide violation(s) found. Commit will be aborted.
+    if [ "$CHECK_PUPPET_LINT" = "permissive" ] ; then
+        echo -e "$(tput setaf 6)Puppet-lint run in permissive mode. Commit won't be aborted$(tput sgr0)"
+    else
+        echo -e "Error: $syntax_errors styleguide violation(s) found. Commit will be aborted.
 Please follow the puppet style guide outlined at:
 http://docs.puppetlabs.com/guides/style_guide.html" | sed -e "s/^/$(tput setaf 1)/" -e "s/$/$(tput sgr0)/"
     exit 1
+    fi
 fi
 
 exit 0

--- a/pre-commit
+++ b/pre-commit
@@ -32,6 +32,12 @@ if [ -f "$git_root/.git" ]; then
     fi
 fi
 
+# Decide if we want puppet-lint
+CHECK_PUPPET_LINT=true
+if [ -e ${subhook_root}/config.cfg ] ; then
+    source ${subhook_root}/config.cfg
+fi
+
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
 
@@ -85,16 +91,18 @@ for changedfile in `git diff --cached --name-only --diff-filter=ACM`; do
     fi
 
     #puppet manifest styleguide compliance
-    if type puppet-lint >/dev/null 2>&1; then
-        if [ $(echo $changedfile | grep -q '\.*.pp$' ; echo $?) -eq 0 ]; then
-            ${subhook_root}/puppet_lint_checks.sh $changedfile
-            RC=$?
-            if [ "$RC" -ne 0 ]; then
-                failures=`expr $failures + 1`
+    if [ "$CHECK_PUPPET_LINT" = true ] ; then
+        if type puppet-lint >/dev/null 2>&1; then
+            if [ $(echo $changedfile | grep -q '\.*.pp$' ; echo $?) -eq 0 ]; then
+                ${subhook_root}/puppet_lint_checks.sh $changedfile
+                RC=$?
+                if [ "$RC" -ne 0 ]; then
+                    failures=`expr $failures + 1`
+                fi
             fi
+        else
+            echo "puppet-lint not installed. Skipping puppet-lint tests..."
         fi
-    else
-        echo "puppet-lint not installed. Skipping puppet-lint tests..."
     fi
 done
 IFS=$SAVEIFS

--- a/pre-commit
+++ b/pre-commit
@@ -33,7 +33,7 @@ if [ -f "$git_root/.git" ]; then
 fi
 
 # Decide if we want puppet-lint
-CHECK_PUPPET_LINT=true
+CHECK_PUPPET_LINT="enabled"
 if [ -e ${subhook_root}/config.cfg ] ; then
     source ${subhook_root}/config.cfg
 fi
@@ -91,10 +91,10 @@ for changedfile in `git diff --cached --name-only --diff-filter=ACM`; do
     fi
 
     #puppet manifest styleguide compliance
-    if [ "$CHECK_PUPPET_LINT" = true ] ; then
+    if [ "$CHECK_PUPPET_LINT" != "disabled" ] ; then
         if type puppet-lint >/dev/null 2>&1; then
             if [ $(echo $changedfile | grep -q '\.*.pp$' ; echo $?) -eq 0 ]; then
-                ${subhook_root}/puppet_lint_checks.sh $changedfile
+                ${subhook_root}/puppet_lint_checks.sh $CHECK_PUPPET_LINT $changedfile
                 RC=$?
                 if [ "$RC" -ne 0 ]; then
                     failures=`expr $failures + 1`

--- a/pre-receive
+++ b/pre-receive
@@ -28,7 +28,7 @@ fi
 export TERM
 
 # Decide if we want puppet-lint
-CHECK_PUPPET_LINT=true
+CHECK_PUPPET_LINT="enabled"
 if [ -e ${subhook_root}/config.cfg ] ; then
     source ${subhook_root}/config.cfg
 fi
@@ -93,10 +93,10 @@ while read oldrev newrev refname; do
         fi
 
         #puppet manifest styleguide compliance
-        if [ "$CHECK_PUPPET_LINT" = true ] ; then
+        if [ "$CHECK_PUPPET_LINT" != "disabled" ] ; then
             if type puppet-lint >/dev/null 2>&1; then
                 if [ $(echo $changedfile | grep -q '\.*.pp$' ; echo $?) -eq 0 ]; then
-                    ${subhook_root}/puppet_lint_checks.sh $tmpmodule "${tmptree}/"
+                    ${subhook_root}/puppet_lint_checks.sh $CHECK_PUPPET_LINT $tmpmodule "${tmptree}/"
                     RC=$?
                     if [ "$RC" -ne 0 ]; then
                         failures=`expr $failures + 1`

--- a/pre-receive
+++ b/pre-receive
@@ -27,6 +27,12 @@ if [ -z "$TERM" ]; then
 fi
 export TERM
 
+# Decide if we want puppet-lint
+CHECK_PUPPET_LINT=true
+if [ -e ${subhook_root}/config.cfg ] ; then
+    source ${subhook_root}/config.cfg
+fi
+
 while read oldrev newrev refname; do
     git archive $newrev | tar x -C ${tmptree}
 
@@ -87,16 +93,18 @@ while read oldrev newrev refname; do
         fi
 
         #puppet manifest styleguide compliance
-        if type puppet-lint >/dev/null 2>&1; then
-            if [ $(echo $changedfile | grep -q '\.*.pp$' ; echo $?) -eq 0 ]; then 
-                ${subhook_root}/puppet_lint_checks.sh $tmpmodule "${tmptree}/"
-                RC=$?
-                if [ "$RC" -ne 0 ]; then
-                    failures=`expr $failures + 1`
+        if [ "$CHECK_PUPPET_LINT" = true ] ; then
+            if type puppet-lint >/dev/null 2>&1; then
+                if [ $(echo $changedfile | grep -q '\.*.pp$' ; echo $?) -eq 0 ]; then
+                    ${subhook_root}/puppet_lint_checks.sh $tmpmodule "${tmptree}/"
+                    RC=$?
+                    if [ "$RC" -ne 0 ]; then
+                        failures=`expr $failures + 1`
+                    fi
                 fi
+            else
+                echo "puppet-lint not installed. Skipping puppet-lint tests..."
             fi
-        else
-            echo "puppet-lint not installed. Skipping puppet-lint tests..."
         fi
     done
 done


### PR DESCRIPTION
We'd like to have the puppet-lint check optional. 

With this patch, the puppet-lint check can be disabled via a config file and also set into a new "permissive" mode. 

Executing the hook in "permissive" mode will run puppet-lint, print the output but always return 0, so the commit/push won't be aborted in case of not compliance with the style guide.