### PR TITLE
fix rspec_puppet_checks.sh (was working on Linux but not on Mac)

### DIFF
--- a/commit_hooks/rspec_puppet_checks.sh
+++ b/commit_hooks/rspec_puppet_checks.sh
@@ -15,7 +15,7 @@ oldpwd=$(pwd)
 tmpchangedmodules=''
 #get a list of files changed under the modules directory so we can
 #sort/uniq them later
-for changedfile in `git diff --raw --cached --name-only --diff-filter=ACM | grep '^modules' | grep '\.*.pp$\|\.*.rb$'`; do
+for changedfile in `git diff --raw --cached --name-only --diff-filter=ACM | grep '^modules' | egrep '\.pp$|\.rb$'`; do
     changeddir=$(dirname $changedfile | cut -d"/" -f1,2)
     tmpchangedmodules="$tmpchangedmodules\n$changeddir"
 done


### PR DESCRIPTION
LINUX

```
echo modules/foo/manifests/init.pp | grep '^modules' | grep -q '\.*.pp$\|\.*.rb$' ; echo $?
0
```

MAC

```
echo modules/foo/manifests/init.pp | grep '^modules' | grep -q '\.*.pp$\|\.*.rb$' ; echo $?
1
```