### PR TITLE
rspec_puppet_checks.sh: egrep -> grep -E

### DIFF
--- a/commit_hooks/rspec_puppet_checks.sh
+++ b/commit_hooks/rspec_puppet_checks.sh
@@ -15,7 +15,7 @@ oldpwd=$(pwd)
 tmpchangedmodules=''
 #get a list of files changed under the modules directory so we can
 #sort/uniq them later
-for changedfile in `git diff --raw --cached --name-only --diff-filter=ACM | grep '^modules' | egrep '\.pp$|\.rb$'`; do
+for changedfile in `git diff --raw --cached --name-only --diff-filter=ACM | grep '^modules' | grep -E '\.pp$|\.rb$'`; do
     changeddir=$(dirname $changedfile | cut -d"/" -f1,2)
     tmpchangedmodules="$tmpchangedmodules\n$changeddir"
 done


### PR DESCRIPTION
`egrep` is deprecated in favour of `grep -E`