### PR TITLE
erb_template_syntax_check.sh: add -P to erb flags

### DIFF
--- a/commit_hooks/erb_template_syntax_check.sh
+++ b/commit_hooks/erb_template_syntax_check.sh
@@ -16,7 +16,7 @@ fi
 
 # Check ERB template syntax
 echo -e "$(tput setaf 6)Checking erb template syntax for $module_path...$(tput sgr0)"
-cat $1 | erb -x -T - | ruby -c > $error_msg 2>&1
+cat $1 | erb -P -x -T - | ruby -c > $error_msg 2>&1
 if [ $? -ne 0 ]; then
     cat $error_msg | sed -e "s/^/$(tput setaf 1)/" -e "s/$/$(tput sgr0)/"
     syntax_errors=`expr $syntax_errors + 1`


### PR DESCRIPTION
Lack of the -P flag breaks syntax check of erb templates of kickstart files.
Refer to discussion on https://groups.google.com/forum/#!topic/puppet-users/tQsjjIouQWM
erb's -P flag means: 'ignore lines which start with "%"', based on 'erb --help' output.

Lines starting with % are indeed ignored, erb man page seems incorrect.
Provided lines starting with "%" indeed does not contain erb/ruby code,
the -P option should be safe in general.