### PR TITLE
Explicitly disable "--parser future" for incompatible puppet versions.

### DIFF
--- a/pre-receive
+++ b/pre-receive
@@ -34,6 +34,14 @@ USE_PUPPET_FUTURE_PARSER="enabled"
 if [ -e ${subhook_root}/config.cfg ] ; then
     source ${subhook_root}/config.cfg
 fi
+# Only puppet 3.2.1 - 3.8 support "--parser future" option.
+case `puppet -version` in
+  2*) ;&
+  3.0*) ;&
+  3.1*) ;&
+  3.2.0) ;&
+  4*) USE_PUPPET_FUTURE_PARSER="disabled" ;;
+esac
 
 while read oldrev newrev refname; do
     git archive $newrev | tar x -C ${tmptree}
@@ -55,7 +63,7 @@ while read oldrev newrev refname; do
                     failures=`expr $failures + 1`
                 fi
             elif [ $(echo $changedfile | grep -q '\.*\.pp$'; echo $?) -eq 0 ]; then
-                ${subhook_root}/puppet_manifest_syntax_check.sh $tmpmodule "${tmptree}/" USE_PUPPET_FUTURE_PARSER
+                ${subhook_root}/puppet_manifest_syntax_check.sh $tmpmodule "${tmptree}/" $USE_PUPPET_FUTURE_PARSER
                 RC=$?
                 if [ "$RC" -ne 0 ]; then
                     failures=`expr $failures + 1`


### PR DESCRIPTION
The "--parser future" option was introduced in puppet 3.2.1 and removed in puppet 4.0.0rc1.

