### PR TITLE
added check for ruby syntax in pre-receive hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Current supported pre-receive (server side) checks
 * Puppet manifest syntax
 * Puppet epp template syntax
 * Erb template syntax
+* Ruby syntax
 * Puppet-lint
 * Yaml (hiera data) syntax
 

--- a/commit_hooks/json_syntax_check.sh
+++ b/commit_hooks/json_syntax_check.sh
@@ -24,7 +24,7 @@ rm -f $error_msg
 
 if which metadata-json-lint > /dev/null 2>&1; then
     if [[ "$(basename $1)" == 'metadata.json' ]]; then
-        metadata-json-lint $1 2> $error_msg > /dev/null
+        metadata-json-lint $1 2> $error_msg  >&2
         if [ $? -ne 0 ]; then 
             cat $error_msg | sed -e "s/^/$(tput setaf 1)/" -e "s/$/$(tput sgr0)/"
             syntax_errors=`expr $syntax_errors + 1`

--- a/commit_hooks/ruby_syntax_check.sh
+++ b/commit_hooks/ruby_syntax_check.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# This script expects $1 to be passed and for $1 to be the filesystem location
+# to an RB file for which it will run syntax checks against. If $2 is passed,
+# it will be stripped off of the path to provide prettier output, which is
+# particularly useful for server-side hooks when tempdirs are created.
+
+syntax_errors=0
+error_msg=$(mktemp /tmp/error_msg_ruby-syntax.XXXXX)
+
+if [ $2 ]; then
+    module_path=$(echo $1 | sed -e 's|'$2'||')
+else
+    module_path=$1
+fi
+
+# Check ruby template syntax
+echo -e "$(tput setaf 6)Checking ruby syntax for $module_path...$(tput sgr0)"
+cat $1 | ruby -c > $error_msg 2>&1
+if [ $? -ne 0 ]; then
+    cat $error_msg | sed -e "s/^/$(tput setaf 1)/" -e "s/$/$(tput sgr0)/"
+    syntax_errors=`expr $syntax_errors + 1`
+    echo -e "$(tput setaf 1)Error: ruby syntax error in $module_path (see above)$(tput sgr0)"
+fi
+rm $error_msg
+
+if [ "$syntax_errors" -ne 0 ]; then
+    echo -e "$(tput setaf 1)Error: $syntax_errors syntax errors found in ruby files. Commit will be aborted.$(tput sgr0)"
+    exit 1
+fi
+
+exit 0
+

--- a/pre-receive
+++ b/pre-receive
@@ -75,7 +75,7 @@ while read oldrev newrev refname; do
 
         if type ruby >/dev/null 2>&1; then
             #check ruby syntax
-            if [ $(echo $changedfile | grep -q '\.*.rb$'; echo $?) -eq 0 ]; then
+            if [ $(echo $changedfile | grep -q '\.*\.rb$'; echo $?) -eq 0 ]; then
                 ${subhook_root}/ruby_syntax_check.sh $tmpmodule "${tmptree}/"
                 RC=$?
                 if [ "$RC" -ne 0 ]; then
@@ -85,7 +85,7 @@ while read oldrev newrev refname; do
             
             #check erb (template file) syntax
             if type erb >/dev/null 2>&1; then
-                if [ $(echo $changedfile | grep -q '\.*.erb$'; echo $?) -eq 0 ]; then
+                if [ $(echo $changedfile | grep -q '\.*\.erb$'; echo $?) -eq 0 ]; then
                     ${subhook_root}/erb_template_syntax_check.sh $tmpmodule "${tmptree}/"
                     RC=$?
                     if [ "$RC" -ne 0 ]; then
@@ -97,7 +97,7 @@ while read oldrev newrev refname; do
             fi
 
             #check hiera data (yaml/yml) syntax
-            if [ $(echo $changedfile | grep -q '\.*.yaml$\|\.*.yml$'; echo $?) -eq 0 ]; then 
+            if [ $(echo $changedfile | grep -q '\.*\.yaml$\|\.*\.yml$'; echo $?) -eq 0 ]; then 
                 ${subhook_root}/yaml_syntax_check.sh $tmpmodule "${tmptree}/"
                 RC=$?
                 if [ "$RC" -ne 0 ]; then
@@ -106,7 +106,7 @@ while read oldrev newrev refname; do
             fi
             
             #check hiera data (json) syntax
-            if [ $(echo $changedfile | grep -q '\.*.json$'; echo $?) -eq 0 ]; then 
+            if [ $(echo $changedfile | grep -q '\.*\.json$'; echo $?) -eq 0 ]; then 
                 ${subhook_root}/json_syntax_check.sh $tmpmodule "${tmptree}/"
                 RC=$?
                 if [ "$RC" -ne 0 ]; then

--- a/pre-receive
+++ b/pre-receive
@@ -74,6 +74,15 @@ while read oldrev newrev refname; do
         fi
 
         if type ruby >/dev/null 2>&1; then
+            #check ruby syntax
+            if [ $(echo $changedfile | grep -q '\.*.rb$'; echo $?) -eq 0 ]; then
+                ${subhook_root}/ruby_syntax_check.sh $tmpmodule "${tmptree}/"
+                RC=$?
+                if [ "$RC" -ne 0 ]; then
+                    failures=`expr $failures + 1`
+                fi
+            fi
+            
             #check erb (template file) syntax
             if type erb >/dev/null 2>&1; then
                 if [ $(echo $changedfile | grep -q '\.*.erb$'; echo $?) -eq 0 ]; then
@@ -105,7 +114,7 @@ while read oldrev newrev refname; do
                 fi
             fi
         else
-            echo "ruby not installed. Skipping erb/yaml checks..."
+            echo "ruby not installed. Skipping erb/yaml/ruby checks..."
         fi
 
         #puppet manifest styleguide compliance


### PR DESCRIPTION
Hi,

I've added support for checking ruby syntax of .rb-file in the pre-receive hook. It's usefull for checking syntax of custom facts, parser functions and types and providers you are commiting.