### PR TITLE
Fix various BASH'isms

### DIFF
--- a/commit_hooks/erb_template_syntax_check.sh
+++ b/commit_hooks/erb_template_syntax_check.sh
@@ -6,23 +6,23 @@
 # particularly useful for server-side hooks when tempdirs are created.
 
 syntax_errors=0
-error_msg=$(mktemp /tmp/error_msg_erb-syntax.XXXXX)
+error_msg="$(mktemp /tmp/error_msg_erb-syntax.XXXXX)"
 
-if [ $2 ]; then
-    module_path=$(echo $1 | sed -e 's|'$2'||')
+if [[ $2 ]]; then
+    module_path="${1##*$2}"
 else
     module_path=$1
 fi
 
 # Check ERB template syntax
 echo -e "$(tput setaf 6)Checking erb template syntax for $module_path...$(tput sgr0)"
-cat $1 | erb -P -x -T - | ruby -c > $error_msg 2>&1
+erb -P -x -T - "$1" | ruby -c 2> "$error_msg" 1>&2
 if [ $? -ne 0 ]; then
-    cat $error_msg | sed -e "s/^/$(tput setaf 1)/" -e "s/$/$(tput sgr0)/"
-    syntax_errors=`expr $syntax_errors + 1`
+    sed -e "s/^/$(tput setaf 1)/" -e "s/$/$(tput sgr0)/" "$error_msg"
+    syntax_errors=$((syntax_errors + 1))
     echo -e "$(tput setaf 1)Error: erb syntax error in $module_path (see above)$(tput sgr0)"
 fi
-rm $error_msg
+rm -f "$error_msg"
 
 if [ "$syntax_errors" -ne 0 ]; then
     echo -e "$(tput setaf 1)Error: $syntax_errors syntax errors found in templates. Commit will be aborted.$(tput sgr0)"

--- a/commit_hooks/puppet_lint_checks.sh
+++ b/commit_hooks/puppet_lint_checks.sh
@@ -9,10 +9,10 @@ manifest_path="$2"
 module_dir="$3"
 
 syntax_errors=0
-error_msg=$(mktemp /tmp/error_msg_puppet-lint.XXXXX)
+error_msg="$(mktemp /tmp/error_msg_puppet-lint.XXXXX)"
 
-if [ $module_dir ]; then
-    manifest_name=$(echo $manifest_path | sed -e 's|'$module_dir'||')
+if [[ $module_dir ]]; then
+    manifest_name="${manifest_path##*$module_dir}"
     error_msg_filter="sed -e s|$module_dir||"
 else
     manifest_name="$manifest_path"
@@ -20,13 +20,13 @@ else
 fi
 
 # De-lint puppet manifests
-echo -e "$(tput setaf 6)Checking puppet style guide compliance for $manifest_name...$(tput sgr0)"
+echo -e "$(tput setaf 6)Checking puppet style guide compliance for ${manifest_name}...$(tput sgr0)"
 
 # If a file named .puppet-lint.rc exists at the base of the repo then use it to
 # enable or disable checks.
 puppet_lint_cmd="puppet-lint --fail-on-warnings --with-filename --relative"
 puppet_lint_rcfile="${3}.puppet-lint.rc"
-if [ -f $puppet_lint_rcfile ]; then
+if [[ -f $puppet_lint_rcfile ]]; then
     echo -e "$(tput setaf 6)Applying custom config from ${puppet_lint_rcfile}$(tput sgr0)"
     puppet_lint_cmd="$puppet_lint_cmd --config $puppet_lint_rcfile"
 else
@@ -35,23 +35,23 @@ fi
 
 # If a file named .puppet-lint.rc exists in the directory where the file is located
 # enable or disable checks.
-puppet_lint_rcfile=`dirname ${manifest_name}`"/.puppet-lint.rc"
-if [ -f $puppet_lint_rcfile ]; then
+puppet_lint_rcfile="$(dirname "$manifest_name")/.puppet-lint.rc"
+if [[ -f $puppet_lint_rcfile ]]; then
     echo -e "$(tput setaf 6)Applying custom config from ${puppet_lint_rcfile}$(tput sgr0)"
     puppet_lint_cmd="$puppet_lint_cmd --config $puppet_lint_rcfile"
 fi
 
-$puppet_lint_cmd $2 2>&1 > $error_msg
+$puppet_lint_cmd "$2" 2>"$error_msg" >&2
 RC=$?
-if [ $RC -ne 0 ]; then
-    syntax_errors=$(expr $syntax_errors + 1)
-    cat $error_msg | $error_msg_filter -e "s/^/$(tput setaf 1)/" -e "s/$/$(tput sgr0)/"
+if [[ $RC -ne 0 ]]; then
+  syntax_errors=$((syntax_errors + 1))
+    $error_msg_filter -e "s/^/$(tput setaf 1)/" -e "s/$/$(tput sgr0)/" < "$error_msg"
     echo -e "$(tput setaf 1)Error: styleguide violation in $manifest_name (see above)$(tput sgr0)"
 fi
-rm -f $error_msg
+rm -f "$error_msg"
 
-if [ $syntax_errors -ne 0 ]; then
-    if [ "$CHECK_PUPPET_LINT" = "permissive" ] ; then
+if [[ $syntax_errors -ne 0 ]]; then
+    if [[ $CHECK_PUPPET_LINT == "permissive" ]] ; then
         echo -e "$(tput setaf 6)Puppet-lint run in permissive mode. Commit won't be aborted$(tput sgr0)"
     else
         echo -e "Error: $syntax_errors styleguide violation(s) found. Commit will be aborted.

--- a/commit_hooks/puppet_lint_checks.sh
+++ b/commit_hooks/puppet_lint_checks.sh
@@ -44,7 +44,7 @@ fi
 $puppet_lint_cmd "$2" 2>"$error_msg" >&2
 RC=$?
 if [[ $RC -ne 0 ]]; then
-  syntax_errors=$((syntax_errors + 1))
+  syntax_errors=$(wc -l "$error_msg" | awk '{print $1}')
     $error_msg_filter -e "s/^/$(tput setaf 1)/" -e "s/$/$(tput sgr0)/" < "$error_msg"
     echo -e "$(tput setaf 1)Error: styleguide violation in $manifest_name (see above)$(tput sgr0)"
 fi

--- a/commit_hooks/puppet_manifest_syntax_check.sh
+++ b/commit_hooks/puppet_manifest_syntax_check.sh
@@ -10,8 +10,8 @@ USE_PUPPET_FUTURE_PARSER="$3"
 syntax_errors=0
 error_msg=$(mktemp /tmp/error_msg_puppet-syntax.XXXXX)
 
-if [ $module_dir ]; then
-    manifest_name=$(echo $manifest_path | sed -e 's|'$module_dir'||')
+if [[ $module_dir ]]; then
+    manifest_name="${manifest_path##*$module_dir}"
     error_msg_filter="sed -e s|$module_dir||"
 else
     manifest_name="$manifest_path"
@@ -21,20 +21,20 @@ fi
 # Get list of new/modified manifest and template files to check (in git index)
 # Check puppet manifest syntax
 echo -e "$(tput setaf 6)Checking puppet manifest syntax for $manifest_name...$(tput sgr0)"
-if [ "$USE_PUPPET_FUTURE_PARSER" != "enabled" ]; then
-    puppet parser validate --color=false $1 > $error_msg 2>&1
+if [[ $USE_PUPPET_FUTURE_PARSER != "enabled" ]]; then
+    puppet parser validate --color=false "$1" > "$error_msg" 2>&1
 else
-    puppet parser validate --parser future --color=false $1 > $error_msg 2>&1
+    puppet parser validate --parser future --color=false "$1" > "$error_msg" 2>&1
 fi
 
-if [ $? -ne 0 ]; then
-    syntax_errors=`expr $syntax_errors + 1`
-    cat $error_msg | $error_msg_filter -e "s/^/$(tput setaf 1)/" -e "s/$/$(tput sgr0)/"
+if [[ $? -ne 0 ]]; then
+  syntax_errors=$((syntax_errors + 1))
+    $error_msg_filter -e "s/^/$(tput setaf 1)/" -e "s/$/$(tput sgr0)/" < "$error_msg"
     echo -e "$(tput setaf 1)Error: puppet syntax error in $manifest_name (see above)$(tput sgr0)"
 fi
-rm -f $error_msg
+rm -f "$error_msg"
 
-if [ "$syntax_errors" -ne 0 ]; then
+if [[ $syntax_errors -ne 0 ]]; then
     echo -e "$(tput setaf 1)Error: $syntax_errors syntax error(s) found in puppet manifests. Commit will be aborted.$(tput sgr0)"
     exit 1
 fi

--- a/commit_hooks/yaml_syntax_check.sh
+++ b/commit_hooks/yaml_syntax_check.sh
@@ -6,23 +6,23 @@
 syntax_errors=0
 error_msg=$(mktemp /tmp/error_msg_yaml-syntax.XXXXX)
 
-if [ $2 ]; then
-    module_path=$(echo $1 | sed -e 's|'$2'||')
+if [[ $2 ]]; then
+    module_path="${1##*$2}"
 else
     module_path=$1
 fi
 
 # Check YAML file syntax
 echo -e "$(tput setaf 6)Checking yaml syntax for $module_path...$(tput sgr0)"
-ruby -e "require 'yaml'; YAML.parse(File.open('$1'))" 2> $error_msg > /dev/null
+ruby -e "require 'yaml'; YAML.parse(File.open('$1'))" 2> "$error_msg" > /dev/null
 if [ $? -ne 0 ]; then
-    cat $error_msg | sed -e "s/^/$(tput setaf 1)/" -e "s/$/$(tput sgr0)/"
-    syntax_errors=`expr $syntax_errors + 1`
+    sed -e "s/^/$(tput setaf 1)/" -e "s/$/$(tput sgr0)/" "$error_msg"
+    syntax_errors=$((syntax_errors + 1))
     echo -e "$(tput setaf 1)Error: yaml syntax error in $module_path (see above)$(tput sgr0)"
 fi
-rm -f $error_msg
+rm -f "$error_msg"
 
-if [ "$syntax_errors" -ne 0 ]; then
+if [[ $syntax_errors -ne 0 ]]; then
     echo -e "$(tput setaf 1)Error: $syntax_errors syntax error(s) found in hiera yaml. Commit will be aborted.$(tput sgr0)"
     exit 1
 fi

--- a/pre-commit
+++ b/pre-commit
@@ -2,59 +2,59 @@
 
 TERM=${TERM:-unknown}; export TERM
 
-git_root=`git rev-parse --show-toplevel`
+git_root=$(git rev-parse --show-toplevel)
 failures=0
 RC=0
 
-hook_dir="$(dirname $0)"
-hook_symlink="$(readlink $0)"
+hook_dir="$(dirname "$0")"
+hook_symlink="$(readlink "$0")"
 
 # Figure out where commit hooks are
-if [ ! -z "$hook_symlink" ] && ! [[ "$hook_symlink" == ../* ]]; then
+if [[ ! -z "$hook_symlink" ]] && ! [[ "$hook_symlink" == ../* ]]; then
   #pre-commit is setup as a symlink
-  subhook_root="$(dirname $hook_symlink)/commit_hooks"
+  subhook_root="$(dirname "$hook_symlink")/commit_hooks"
 else
   #commit_hooks should be with pre-commit
   subhook_root="${hook_dir}/commit_hooks"
 fi
 
 # If using submodules, we need to read proper subhook root
-if [ -f "$git_root/.git" ]; then
+if [[ -f "$git_root/.git" ]]; then
     IFS=": "
     while read -r name value
     do
-        if [ $name == "gitdir" ]; then
+        if [[ $name == "gitdir" ]]; then
             submodule_hookdir=$value
         fi
     done < "$git_root/.git"
-    if [ ! -z "$submodule_hookdir" ]; then
+    if [[ ! -z "$submodule_hookdir" ]]; then
         subhook_root="$git_root/$submodule_hookdir/hooks/commit_hooks"
     fi
 fi
 
 # Decide if we want puppet-lint
 CHECK_PUPPET_LINT="enabled"
-if [ -e ${subhook_root}/config.cfg ] ; then
-    source ${subhook_root}/config.cfg
+if [[ -e ${subhook_root}/config.cfg ]] ; then
+    source "${subhook_root}/config.cfg"
 fi
 
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
 
-for changedfile in `git diff --cached --name-only --diff-filter=ACM`; do
+for changedfile in $(git diff --cached --name-only --diff-filter=ACM); do
     #check puppet manifest syntax
     if type puppet >/dev/null 2>&1; then
-        if [ $(echo $changedfile | grep -q '\.*\.epp$'; echo $?) -eq 0 ]; then
-            ${subhook_root}/puppet_epp_syntax_check.sh $changedfile
+        if [[ $(echo "$changedfile" | grep -q '\.*\.epp$'; echo $?) -eq 0 ]]; then
+            ${subhook_root}/puppet_epp_syntax_check.sh "$changedfile"
             RC=$?
-            if [ "$RC" -ne 0 ]; then
-                failures=`expr $failures + 1`
+            if [[ "$RC" -ne 0 ]]; then
+                failures=$((failures + 1))
             fi
-        elif [ $(echo $changedfile | grep -q '\.*\.pp$'; echo $?) -eq 0 ]; then
-            ${subhook_root}/puppet_manifest_syntax_check.sh $changedfile
+        elif [[ $(echo "$changedfile" | grep -q '\.*\.pp$'; echo $?) -eq 0 ]]; then
+            ${subhook_root}/puppet_manifest_syntax_check.sh "$changedfile"
             RC=$?
-            if [ "$RC" -ne 0 ]; then
-                failures=`expr $failures + 1`
+            if [[ "$RC" -ne 0 ]]; then
+                failures=$((failures + 1))
             fi
         fi
     else
@@ -64,11 +64,11 @@ for changedfile in `git diff --cached --name-only --diff-filter=ACM`; do
     if type ruby >/dev/null 2>&1; then
         #check erb (template file) syntax
         if type erb >/dev/null 2>&1; then
-            if [ $(echo $changedfile | grep -q '\.*.erb$'; echo $?) -eq 0 ]; then
-                ${subhook_root}/erb_template_syntax_check.sh $changedfile
+            if [[ $(echo "$changedfile" | grep -q '\.*.erb$'; echo $?) -eq 0 ]]; then
+                ${subhook_root}/erb_template_syntax_check.sh "$changedfile"
                 RC=$?
-                if [ "$RC" -ne 0 ]; then
-                    failures=`expr $failures + 1`
+                if [[ "$RC" -ne 0 ]]; then
+                    failures=$((failures + 1))
                 fi
             fi
         else
@@ -76,20 +76,20 @@ for changedfile in `git diff --cached --name-only --diff-filter=ACM`; do
         fi
 
         #check hiera data (yaml/yml/eyaml/eyml) syntax
-        if [ $(echo $changedfile | grep -q '\.*.e\?ya\?ml$'; echo $?) -eq 0 ]; then
-            ${subhook_root}/yaml_syntax_check.sh $changedfile
+        if [[ $(echo "$changedfile" | grep -q '\.*.e\?ya\?ml$'; echo $?) -eq 0 ]]; then
+            ${subhook_root}/yaml_syntax_check.sh "$changedfile"
             RC=$?
-            if [ "$RC" -ne 0 ]; then
-                failures=`expr $failures + 1`
+            if [[ "$RC" -ne 0 ]]; then
+                failures=$((failures + 1))
             fi
         fi
 
         #check json (i.e. metadata.json) syntax
-        if [ $(echo $changedfile | grep -q '\.*.json$'; echo $?) -eq 0 ]; then
-            ${subhook_root}/json_syntax_check.sh $changedfile
+        if [[ $(echo "$changedfile" | grep -q '\.*.json$'; echo $?) -eq 0 ]]; then
+            ${subhook_root}/json_syntax_check.sh "$changedfile"
             RC=$?
-            if [ "$RC" -ne 0 ]; then
-                failures=`expr $failures + 1`
+            if [[ "$RC" -ne 0 ]]; then
+                failures=$((failures + 1))
             fi
         fi
     else
@@ -97,13 +97,13 @@ for changedfile in `git diff --cached --name-only --diff-filter=ACM`; do
     fi
 
     #puppet manifest styleguide compliance
-    if [ "$CHECK_PUPPET_LINT" != "disabled" ] ; then
+    if [[ "$CHECK_PUPPET_LINT" != "disabled" ]] ; then
         if type puppet-lint >/dev/null 2>&1; then
-            if [ $(echo $changedfile | grep -q '\.*\.pp$' ; echo $?) -eq 0 ]; then
-                ${subhook_root}/puppet_lint_checks.sh $CHECK_PUPPET_LINT $changedfile
+            if [[ $(echo "$changedfile" | grep -q '\.*\.pp$' ; echo $?) -eq 0 ]]; then
+                ${subhook_root}/puppet_lint_checks.sh "$CHECK_PUPPET_LINT" "$changedfile"
                 RC=$?
-                if [ "$RC" -ne 0 ]; then
-                    failures=`expr $failures + 1`
+                if [[ "$RC" -ne 0 ]]; then
+                    failures=$((failures + 1))
                 fi
             fi
         else
@@ -117,8 +117,8 @@ IFS=$SAVEIFS
 if which rspec >/dev/null 2>&1; then
     ${subhook_root}/rspec_puppet_checks.sh
     RC=$?
-    if [ "$RC" -ne 0 ]; then
-        failures=`expr $failures + 1`
+    if [[ "$RC" -ne 0 ]]; then
+        failures=$((failures + 1))
     fi
 else
     echo "rspec not installed. Skipping rspec-puppet tests..."
@@ -126,11 +126,11 @@ fi
 
 #r10k puppetfile syntax check
 if which r10k >/dev/null 2>&1; then
-  if [ "$changedfile" = "Puppetfile" ]; then
-        ${subhook_root}/r10k_syntax_check.sh
+  if [[ "$changedfile" = "Puppetfile" ]]; then
+        "${subhook_root}/r10k_syntax_check.sh"
         RC=$?
-        if [ "$RC" -ne 0 ]; then
-                failures=`expr $failures + 1`
+        if [[ "$RC" -ne 0 ]]; then
+                failures=$((failures + 1))
         fi
   fi
 else
@@ -138,7 +138,7 @@ else
 fi
 
 #summary
-if [ "$failures" -ne 0 ]; then
+if [[ "$failures" -ne 0 ]]; then
     echo -e "$(tput setaf 1)Error: $failures subhooks failed. Aborting commit.$(tput sgr0)"
     exit 1
 fi

--- a/pre-receive
+++ b/pre-receive
@@ -1,20 +1,21 @@
 #!/bin/bash
 
 # Puppet attempts to source ~/.puppet and will error if $HOME is not set
-if [ -z $HOME ]
+if [[ -z $HOME ]]
 then
-  export HOME=$(grep "${USER}:" /etc/passwd | awk -F ':' '{print $6}')
+  HOME="$(grep "${USER}:" /etc/passwd | awk -F ':' '{print $6}')"
+  export HOME
 fi
 
 failures=0
 RC=0
 
-hook_dir="$(dirname $0)"
-hook_symlink="$(readlink -f $0)"
+hook_dir="$(dirname "$0")"
+hook_symlink="$(readlink -f "$0")"
 
 # Figure out where commit hooks are if pre-receive is setup as a symlink
-if [ ! -z "$hook_symlink" ]; then
-  subhook_root="$(dirname $hook_symlink)/commit_hooks"
+if [[ ! -z "$hook_symlink" ]]; then
+  subhook_root="$(dirname "$hook_symlink")/commit_hooks"
 else
   subhook_root="$hook_dir/commit_hooks"
 fi
@@ -22,7 +23,7 @@ fi
 tmptree=$(mktemp -d)
 
 # Prevent tput from throwing an error by ensuring that $TERM is always set
-if [ -z "$TERM" ]; then
+if [[ -z "$TERM" ]]; then
     TERM=dumb
 fi
 export TERM
@@ -31,42 +32,38 @@ export TERM
 # Decide if we want the puppet future parser (already on puppet 4?)
 CHECK_PUPPET_LINT="enabled"
 USE_PUPPET_FUTURE_PARSER="enabled"
-if [ -e ${subhook_root}/config.cfg ] ; then
-    source ${subhook_root}/config.cfg
+if [[ -e ${subhook_root}/config.cfg ]] ; then
+    source "${subhook_root}/config.cfg"
 fi
 # Only puppet 3.2.1 - 3.8 support "--parser future" option.
-case `puppet --version` in
-  2*) ;&
-  3.0*) ;&
-  3.1*) ;&
-  3.2.0) ;&
+case $(puppet --version) in
   4*) USE_PUPPET_FUTURE_PARSER="disabled" ;;
 esac
 
-while read oldrev newrev refname; do
-    git archive $newrev | tar x -C ${tmptree}
+while read -r oldrev newrev refname; do
+    git archive "$newrev" | tar x -C "$tmptree"
 
-		# for a new branch oldrev is 0{40}, set newrev to branch name and oldrev to parent branch
-		if [[ $oldrev == "0000000000000000000000000000000000000000" ]]; then
-						newrev=`git rev-parse --abbrev-ref HEAD`
-						oldrev=`git show-branch | grep '\*' | grep -v "$newrev" | head -n1 | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//'`
-		fi
+    # for a new branch oldrev is 0{40}, set newrev to branch name and oldrev to parent branch
+    if [[ $oldrev == "0000000000000000000000000000000000000000" ]]; then
+      newrev=$(git rev-parse --abbrev-ref HEAD)
+      oldrev=$(git show-branch | grep '\*' | grep -v "$newrev" | head -n1 | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//')
+    fi
 
-    for changedfile in $(git diff --name-only $oldrev $newrev --diff-filter=ACM); do
+    for changedfile in $(git diff --name-only "$oldrev" "$newrev" --diff-filter=ACM); do
         tmpmodule="$tmptree/$changedfile"
         #check puppet manifest syntax
         if type puppet >/dev/null 2>&1; then
-            if [ $(echo $changedfile | grep -q '\.*\.epp$'; echo $?) -eq 0 ]; then
-                ${subhook_root}/puppet_epp_syntax_check.sh $tmpmodule "${tmptree}/"
+            if [[ $(echo "$changedfile" | grep -q '\.*\.epp$'; echo $?) -eq 0 ]]; then
+                ${subhook_root}/puppet_epp_syntax_check.sh "$tmpmodule" "${tmptree}/"
                 RC=$?
-                if [ "$RC" -ne 0 ]; then
-                    failures=`expr $failures + 1`
+                if [[ $RC -ne 0 ]]; then
+                  failures=$((failures + 1))
                 fi
-            elif [ $(echo $changedfile | grep -q '\.*\.pp$'; echo $?) -eq 0 ]; then
-                ${subhook_root}/puppet_manifest_syntax_check.sh $tmpmodule "${tmptree}/" $USE_PUPPET_FUTURE_PARSER
+            elif [[ $(echo "$changedfile" | grep -q '\.*\.pp$'; echo $?) -eq 0 ]]; then
+                ${subhook_root}/puppet_manifest_syntax_check.sh "$tmpmodule" "${tmptree}/" "$USE_PUPPET_FUTURE_PARSER"
                 RC=$?
-                if [ "$RC" -ne 0 ]; then
-                    failures=`expr $failures + 1`
+                if [[ $RC -ne 0 ]]; then
+                  failures=$((failures + 1))
                 fi
             fi
         else
@@ -75,21 +72,21 @@ while read oldrev newrev refname; do
 
         if type ruby >/dev/null 2>&1; then
             #check ruby syntax
-            if [ $(echo $changedfile | grep -q '\.*\.rb$'; echo $?) -eq 0 ]; then
-                ${subhook_root}/ruby_syntax_check.sh $tmpmodule "${tmptree}/"
+            if [[ $(echo "$changedfile" | grep -q '\.*\.rb$'; echo $?) -eq 0 ]]; then
+                ${subhook_root}/ruby_syntax_check.sh "$tmpmodule" "${tmptree}/"
                 RC=$?
-                if [ "$RC" -ne 0 ]; then
-                    failures=`expr $failures + 1`
+                if [[ $RC -ne 0 ]]; then
+                  failures=$((failures + 1))
                 fi
             fi
-            
+
             #check erb (template file) syntax
             if type erb >/dev/null 2>&1; then
-                if [ $(echo $changedfile | grep -q '\.*\.erb$'; echo $?) -eq 0 ]; then
-                    ${subhook_root}/erb_template_syntax_check.sh $tmpmodule "${tmptree}/"
+                if [[ $(echo "$changedfile" | grep -q '\.*\.erb$'; echo $?) -eq 0 ]]; then
+                    ${subhook_root}/erb_template_syntax_check.sh "$tmpmodule" "${tmptree}/"
                     RC=$?
-                    if [ "$RC" -ne 0 ]; then
-                        failures=`expr $failures + 1`
+                    if [[ $RC -ne 0 ]]; then
+                      failures=$((failures + 1))
                     fi
                 fi
             else
@@ -97,20 +94,20 @@ while read oldrev newrev refname; do
             fi
 
             #check hiera data (yaml/yml) syntax
-            if [ $(echo $changedfile | grep -q '\.*\.yaml$\|\.*\.yml$'; echo $?) -eq 0 ]; then 
-                ${subhook_root}/yaml_syntax_check.sh $tmpmodule "${tmptree}/"
+            if [[ $(echo "$changedfile" | grep -q '\.*\.yaml$\|\.*\.yml$'; echo $?) -eq 0 ]]; then
+                ${subhook_root}/yaml_syntax_check.sh "$tmpmodule" "${tmptree}/"
                 RC=$?
-                if [ "$RC" -ne 0 ]; then
-                    failures=`expr $failures + 1`
+                if [[ $RC -ne 0 ]]; then
+                  failures=$((failures + 1))
                 fi
             fi
-            
+
             #check hiera data (json) syntax
-            if [ $(echo $changedfile | grep -q '\.*\.json$'; echo $?) -eq 0 ]; then 
-                ${subhook_root}/json_syntax_check.sh $tmpmodule "${tmptree}/"
+            if [[ $(echo "$changedfile" | grep -q '\.*\.json$'; echo $?) -eq 0 ]]; then
+                ${subhook_root}/json_syntax_check.sh "$tmpmodule" "${tmptree}/"
                 RC=$?
-                if [ "$RC" -ne 0 ]; then
-                    failures=`expr $failures + 1`
+                if [[ $RC -ne 0 ]]; then
+                  failures=$((failures + 1))
                 fi
             fi
         else
@@ -118,13 +115,13 @@ while read oldrev newrev refname; do
         fi
 
         #puppet manifest styleguide compliance
-        if [ "$CHECK_PUPPET_LINT" != "disabled" ] ; then
+        if [[ $CHECK_PUPPET_LINT != "disabled" ]] ; then
             if type puppet-lint >/dev/null 2>&1; then
-                if [ $(echo $changedfile | grep -q '\.*\.pp$' ; echo $?) -eq 0 ]; then
-                    ${subhook_root}/puppet_lint_checks.sh $CHECK_PUPPET_LINT $tmpmodule "${tmptree}/"
+                if [[ $(echo "$changedfile" | grep -q '\.*\.pp$' ; echo $?) -eq 0 ]]; then
+                    ${subhook_root}/puppet_lint_checks.sh "$CHECK_PUPPET_LINT" "$tmpmodule" "${tmptree}/"
                     RC=$?
-                    if [ "$RC" -ne 0 ]; then
-                        failures=`expr $failures + 1`
+                    if [[ $RC -ne 0 ]]; then
+                      failures=$((failures + 1))
                     fi
                 fi
             else
@@ -133,10 +130,10 @@ while read oldrev newrev refname; do
         fi
     done
 done
-rm -rf ${tmptree}
+rm -rf "$tmptree"
 
 #summary
-if [ "$failures" -ne 0 ]; then
+if [[ $failures -ne 0 ]]; then
     echo -e "$(tput setaf 1)Error: $failures subhooks failed. Declining push.$(tput sgr0)"
     exit 1
 fi


### PR DESCRIPTION
This PR encompasses commits that fix BASH style and standards issues. For example, using BASH's native parameter expansion instead of shelling out to `sed` or `awk`. By sticking to the standards, it's less likely that odd bugs will pop up down the line.

Most of these changes were made after running the scripts through https://github.com/koalaman/shellcheck and fixing the issues it found.

All of the modified checkers were validated by running some sample bad-code through them to ensure that they still caught errors and that there's no difference in output.