### PR TITLE
Ensure files exist before checking syntax of them

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -42,6 +42,7 @@ SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
 
 for changedfile in $(git diff --cached --name-only --diff-filter=ACM); do
+    [[ -f "$changedfile" ]] || continue
     #check puppet manifest syntax
     if type puppet >/dev/null 2>&1; then
         if [[ $(echo "$changedfile" | grep -q '\.*\.epp$'; echo $?) -eq 0 ]]; then

--- a/pre-receive
+++ b/pre-receive
@@ -51,6 +51,7 @@ while read -r oldrev newrev refname; do
 
     for changedfile in $(git diff --name-only "$oldrev" "$newrev" --diff-filter=ACM); do
         tmpmodule="$tmptree/$changedfile"
+        [[ -f "$tmpmodule" ]] || continue
         #check puppet manifest syntax
         if type puppet >/dev/null 2>&1; then
             if [[ $(echo "$changedfile" | grep -q '\.*\.epp$'; echo $?) -eq 0 ]]; then


### PR DESCRIPTION
One of our branches got confused and started reported filenames that had been deleted many commits ago as changed.  Being non-existent, the hooks couldn't couldn't check the syntax on them and exploded - this change adds simple sanity checks to only proceed with files that actually exist.  Shouldn't happen, but can, and should be handled gracefully.