### PR TITLE
Allow puppet-lint control from config file

### DIFF
--- a/commit_hooks/config.cfg
+++ b/commit_hooks/config.cfg
@@ -1,2 +1,3 @@
 CHECK_PUPPET_LINT="enabled" # enabled, permissive or disabled (permissive runs but return code is ignored)
 USE_PUPPET_FUTURE_PARSER="enabled" # enabled or disabled
+export PUPPET_LINT_OPTIONS="" # puppet-lint options to use if no rc file is present.  Defaults to "--no-80chars-check"

--- a/commit_hooks/puppet_lint_checks.sh
+++ b/commit_hooks/puppet_lint_checks.sh
@@ -11,6 +11,8 @@ module_dir="$3"
 syntax_errors=0
 error_msg="$(mktemp /tmp/error_msg_puppet-lint.XXXXX)"
 
+opts=${PUPPET_LINT_OPTIONS:-"--no-80chars-check"}
+
 if [[ $module_dir ]]; then
     manifest_name="${manifest_path##*$module_dir}"
     error_msg_filter="sed -e s|$module_dir||"
@@ -30,7 +32,7 @@ if [[ -f $puppet_lint_rcfile ]]; then
     echo -e "$(tput setaf 6)Applying custom config from ${puppet_lint_rcfile}$(tput sgr0)"
     puppet_lint_cmd="$puppet_lint_cmd --config $puppet_lint_rcfile"
 else
-    puppet_lint_cmd="$puppet_lint_cmd --no-80chars-check"
+    puppet_lint_cmd="$puppet_lint_cmd $opts"
 fi
 
 # If a file named .puppet-lint.rc exists in the directory where the file is located


### PR DESCRIPTION
Makes to easier to have custom config for puppet-lint checks (for example, we don't enforce documentation check here)