### PR TITLE
Add r10k pre-receive hook

### DIFF
--- a/commit_hooks/r10k_syntax_check.sh
+++ b/commit_hooks/r10k_syntax_check.sh
@@ -3,7 +3,7 @@
 # This script assumes you have installed r10k and will perform a syntax check on the Puppetfile if existing
 
 echo "Performing a syntax check on the r10k Puppetfile:"
-r10k puppetfile check
+PUPPETFILE="$1" r10k puppetfile check
 
 if [[ $? -ne 0 ]]
 then

--- a/pre-commit
+++ b/pre-commit
@@ -115,7 +115,7 @@ done
 IFS=$SAVEIFS
 
 #rspec test validation
-if which rspec >/dev/null 2>&1; then
+if hash rspec >/dev/null 2>&1; then
     ${subhook_root}/rspec_puppet_checks.sh
     RC=$?
     if [[ "$RC" -ne 0 ]]; then
@@ -126,7 +126,7 @@ else
 fi
 
 #r10k puppetfile syntax check
-if which r10k >/dev/null 2>&1; then
+if hash r10k >/dev/null 2>&1; then
   if [[ "$changedfile" = "Puppetfile" ]]; then
         "${subhook_root}/r10k_syntax_check.sh"
         RC=$?

--- a/pre-receive
+++ b/pre-receive
@@ -129,6 +129,18 @@ while read -r oldrev newrev refname; do
                 echo "puppet-lint not installed. Skipping puppet-lint tests..."
             fi
         fi
+        #r10k puppetfile syntax check
+        if hash r10k >/dev/null 2>&1; then
+          if [ "$changedfile" = "Puppetfile" ]; then
+                ${subhook_root}/r10k_syntax_check.sh $tmptree/$changedfile
+                RC=$?
+                if [ "$RC" -ne 0 ]; then
+                       failures=`expr $failures + 1`
+                fi
+          fi
+        else
+            echo "r10k not installed. Skipping r10k Puppetfile test..."
+        fi
     done
 done
 rm -rf "$tmptree"


### PR DESCRIPTION
This adds the ability to run r10k puppet file check as a pre-receive hook.

This only works on older versions of the r10k gem, I've tested with Centos 6 and Ruby 1.2.0

If a newer version of them gem is install the PUPPETFILE environment variable doesn't work, but the command still triggers but always passes with an exit code of 0 so its a noop