### PR TITLE
Added check for metadata.json version against a git tag

### DIFF
--- a/commit_hooks/config.cfg
+++ b/commit_hooks/config.cfg
@@ -1,3 +1,4 @@
 CHECK_PUPPET_LINT="enabled" # enabled, permissive or disabled (permissive runs but return code is ignored)
 USE_PUPPET_FUTURE_PARSER="enabled" # enabled or disabled
+CHECK_TAG_METADATA="enabled" # enabled or disabled
 export PUPPET_LINT_OPTIONS="" # puppet-lint options to use if no rc file is present.  Defaults to "--no-80chars-check"

--- a/commit_hooks/metadata_version_matches_tag.sh
+++ b/commit_hooks/metadata_version_matches_tag.sh
@@ -1,0 +1,60 @@
+#!/bin/bash -u
+
+# This script expects $1 to be passed and for $1 to be the filesystem location
+# 
+# This script expects $2 to be passed and for it to be the tag name
+
+errors=0
+
+module_path=$1
+tag=$2
+
+error_msg=$(mktemp /tmp/error_msg_tag-version.XXXXXX)
+metadata=$(mktemp /tmp/metadata_version.XXXXXX)
+
+echo -e "$(tput setaf 6)Checking metadata matches tag for $tag $(tput sgr0)"
+
+ruby -e "require 'json'; metadata=JSON.parse(File.read('$module_path/metadata.json')); puts metadata['version']" 2> $error_msg > $metadata
+if [ $? -ne 0 ]; then
+    cat $error_msg | sed -e "s/^/$(tput setaf 1)/" -e "s/$/$(tput sgr0)/"
+    errors=`expr $errors + 1`
+    echo -e "$(tput setaf 1)Error: json syntax error in $module_path (see above)$(tput sgr0)"
+    exit 1
+fi
+rm -f $error_msg
+
+meta_tag=$(cat $metadata; rm -f $metadata)
+case $meta_tag in
+  $tag)
+    true
+  ;;
+  [vV]$tag)
+    true
+  ;;
+  "v $tag")
+    true
+  ;;
+  "V $tag")
+    true
+  ;;
+  [vV].$tag)
+    true
+  ;;
+  "v. $tag")
+    true
+  ;;
+  "V. $tag")
+    true
+  ;;
+  *)
+    echo -e "$(tput setaf 1)Error: metadata.json contains $meta_tag but tag is $tag $(tput sgr0)"
+    errors=`expr $errors + 1`
+  ;;
+esac
+
+if [[ $errors -ne 0 ]]; then
+    echo -e "$(tput setaf 1)Error: error(s) found in metadata.json file.  Commit will be aborted.$(tput sgr0)"
+    exit 1
+fi
+
+exit 0

--- a/pre-receive
+++ b/pre-receive
@@ -31,6 +31,7 @@ export TERM
 # Decide if we want puppet-lint
 # Decide if we want the puppet future parser (already on puppet 4?)
 CHECK_PUPPET_LINT="enabled"
+CHECK_TAG_METADATA="enabled"
 USE_PUPPET_FUTURE_PARSER="enabled"
 if [[ -e ${subhook_root}/config.cfg ]] ; then
     source "${subhook_root}/config.cfg"
@@ -47,6 +48,20 @@ while read -r oldrev newrev refname; do
     if [[ $oldrev == "0000000000000000000000000000000000000000" ]]; then
       newrev=$(git rev-parse --abbrev-ref HEAD)
       oldrev=$(git show-branch | grep '\*' | grep -v "$newrev" | head -n1 | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//')
+    fi
+
+    if [[ $CHECK_TAG_METADATA != 'disabled' ]]; then
+        # check that the version in the tag is the version in metadata.json
+        case "$refname" in
+          refs/tags/*)
+            tagname=$(basename $refname)
+            ${subhook_root}/metadata_version_matches_tag.sh "$tmptree" "$tagname"
+            RC=$?
+            if [[ $RC -ne 0 ]]; then
+              failures=$((failures + 1))
+            fi
+          ;;
+        esac
     fi
 
     for changedfile in $(git diff --name-only "$oldrev" "$newrev" --diff-filter=ACM); do


### PR DESCRIPTION
This check will validate that the version set in metadata.json matches the value of a git tag.

It passes against the puppetlabs supported modules and keeps me from doing something silly.