### PR TITLE
Get proper oldrev and newrev values when a new branch is pushed

### DIFF
--- a/pre-receive
+++ b/pre-receive
@@ -44,10 +44,9 @@ esac
 while read -r oldrev newrev refname; do
     git archive "$newrev" | tar x -C "$tmptree"
 
-    # for a new branch oldrev is 0{40}, set newrev to branch name and oldrev to parent branch
+    # for a new branch oldrev is 0{40}, set oldrev to the commit where we branched off the parent
     if [[ $oldrev == "0000000000000000000000000000000000000000" ]]; then
-      newrev=$(git rev-parse --abbrev-ref HEAD)
-      oldrev=$(git show-branch | grep '\*' | grep -v "$newrev" | head -n1 | sed 's/.*\[\(.*\)\].*/\1/' | sed 's/[\^~].*//')
+      oldrev=$(git rev-list --boundary $newrev --not --all | sed -n 's/^-//p')
     fi
 
     files_list=''


### PR DESCRIPTION
If pushing a new branch, don't change newrev, just change oldrev
to the commit where we branched off the parent

This should fix #60 ... Was seeing very odd behavior with the previous logic here...Initially I had thought it might be an issue with gitlab specifically, but after digging in more, I don't really follow the previous logic for this at all (I don't claim to be a git expert though, so I could be missing some corner case)

This makes more logical sense to me and seems to actually provide the correct (changed) files on a new branch for all the possible test cases I could come up with  (With git 2.7.4)