### PR TITLE
Added a config option to enable/disable rspec tests in pre-commit hook

### DIFF
--- a/commit_hooks/config.cfg
+++ b/commit_hooks/config.cfg
@@ -1,5 +1,6 @@
 CHECK_PUPPET_LINT="enabled" # enabled, permissive or disabled (permissive runs but return code is ignored)
 USE_PUPPET_FUTURE_PARSER="enabled" # enabled or disabled
 CHECK_INITIAL_COMMIT="disabled" # enabled or disabled
+CHECK_RSPEC="enabled" # enabled or disabled
 export PUPPET_LINT_OPTIONS="" # puppet-lint options to use if no rc file is present.  Defaults to "--no-80chars-check"
 UNSET_RUBY_ENV="enabled" # enabled or disabled. Required for Gitlab.

--- a/pre-commit
+++ b/pre-commit
@@ -115,14 +115,16 @@ done
 IFS=$SAVEIFS
 
 #rspec test validation
-if hash rspec >/dev/null 2>&1; then
-    ${subhook_root}/rspec_puppet_checks.sh
-    RC=$?
-    if [[ "$RC" -ne 0 ]]; then
-        failures=$((failures + 1))
-    fi
-else
-    echo "rspec not installed. Skipping rspec-puppet tests..."
+if [[ "$CHECK_RSPEC" != "disabled" ]] ; then
+  if hash rspec >/dev/null 2>&1; then
+      ${subhook_root}/rspec_puppet_checks.sh
+      RC=$?
+      if [[ "$RC" -ne 0 ]]; then
+          failures=$((failures + 1))
+      fi
+  else
+      echo "rspec not installed. Skipping rspec-puppet tests..."
+  fi
 fi
 
 #r10k puppetfile syntax check


### PR DESCRIPTION
I needed a simple method to toggle rspec test validation enable/disable.