### PR TITLE
add config option to set the fail-on-warnings flag for puppet lint

### DIFF
--- a/commit_hooks/config.cfg
+++ b/commit_hooks/config.cfg
@@ -3,4 +3,5 @@ USE_PUPPET_FUTURE_PARSER="enabled" # enabled or disabled
 CHECK_INITIAL_COMMIT="disabled" # enabled or disabled
 CHECK_RSPEC="enabled" # enabled or disabled
 export PUPPET_LINT_OPTIONS="" # puppet-lint options to use if no rc file is present.  Defaults to "--no-80chars-check"
+export PUPPET_LINT_FAIL_ON_WARNINGS="true" # Set the puppet-lint option --fail-on-warnings
 UNSET_RUBY_ENV="enabled" # enabled or disabled. Required for Gitlab.

--- a/commit_hooks/puppet_lint_checks.sh
+++ b/commit_hooks/puppet_lint_checks.sh
@@ -59,7 +59,7 @@ if [[ $RC -ne 0 ]]; then
     $error_msg_filter -e "s/^/$(tput setaf 1)/" -e "s/$/$(tput sgr0)/" < "$error_msg"
     echo -e "$(tput setaf 1)Error: styleguide violation in $manifest_name (see above)$(tput sgr0)"
 elif [[ -s $error_msg ]]; then
-  $error_msg_filter -e "s/^/$(tput setaf 1)/" -e "s/$/$(tput sgr0)/" < "$error_msg"
+  $error_msg_filter -e "s/^/$(tput setaf 3)/" -e "s/$/$(tput sgr0)/" < "$error_msg"
   echo -e "$(tput setaf 1)Warning: styleguide violation in $manifest_name (see above)$(tput sgr0)"
 fi
 rm -f "$error_msg"

--- a/commit_hooks/puppet_lint_checks.sh
+++ b/commit_hooks/puppet_lint_checks.sh
@@ -58,6 +58,9 @@ if [[ $RC -ne 0 ]]; then
   syntax_errors=$(wc -l "$error_msg" | awk '{print $1}')
     $error_msg_filter -e "s/^/$(tput setaf 1)/" -e "s/$/$(tput sgr0)/" < "$error_msg"
     echo -e "$(tput setaf 1)Error: styleguide violation in $manifest_name (see above)$(tput sgr0)"
+elif [[ -s $error_msg ]]; then
+  $error_msg_filter -e "s/^/$(tput setaf 1)/" -e "s/$/$(tput sgr0)/" < "$error_msg"
+  echo -e "$(tput setaf 1)Warning: styleguide violation in $manifest_name (see above)$(tput sgr0)"
 fi
 rm -f "$error_msg"
 

--- a/commit_hooks/puppet_lint_checks.sh
+++ b/commit_hooks/puppet_lint_checks.sh
@@ -24,9 +24,18 @@ fi
 # De-lint puppet manifests
 echo -e "$(tput setaf 6)Checking puppet style guide compliance for ${manifest_name}...$(tput sgr0)"
 
+# Set the puppet lint option to fail on warnings if true.
+if [ "${PUPPET_LINT_FAIL_ON_WARNINGS}" = true ]; then
+  puppet_lint_cmd="puppet-lint --fail-on-warnings --with-filename --relative"
+elif [ "${PUPPET_LINT_FAIL_ON_WARNINGS}" = false ]; then
+  puppet_lint_cmd="puppet-lint --with-filename --relative"
+else
+  echo "Configuration Option PUPPET_LINT_FAIL_ON_WARNINGS not set to a boolean value"
+  exit 1
+fi
+
 # If a file named .puppet-lint.rc exists at the base of the repo then use it to
 # enable or disable checks.
-puppet_lint_cmd="puppet-lint --fail-on-warnings --with-filename --relative"
 puppet_lint_rcfile="${3}.puppet-lint.rc"
 if [[ -f $puppet_lint_rcfile ]]; then
     echo -e "$(tput setaf 6)Applying custom config from ${puppet_lint_rcfile}$(tput sgr0)"


### PR DESCRIPTION
When using Puppet 4 there are several instances where puppet-lint incorrect interprets syntax as incorrect when is actually valid.  Such as quote boolean values in a hash or when using .each variable are incorrectly determined as top scope

https://github.com/rodjek/puppet-lint/issues/474

To work around this, I've added a config option to allow one to still commit code that is a warning from the linter.  This defaults to true which will fail on warnings as the hook currently acts.  