### PR TITLE
Add Gemfile and support for puppet-lint >=2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem 'puppet', '3.8.6'
+gem 'rspec-puppet'
+gem 'puppet-lint', '2.0.0'

--- a/commit_hooks/config.cfg
+++ b/commit_hooks/config.cfg
@@ -2,6 +2,6 @@ CHECK_PUPPET_LINT="enabled" # enabled, permissive or disabled (permissive runs b
 USE_PUPPET_FUTURE_PARSER="enabled" # enabled or disabled
 CHECK_INITIAL_COMMIT="disabled" # enabled or disabled
 CHECK_RSPEC="enabled" # enabled or disabled
-export PUPPET_LINT_OPTIONS="" # puppet-lint options to use if no rc file is present.  Defaults to "--no-80chars-check"
+export PUPPET_LINT_OPTIONS="" # puppet-lint options to use if no rc file is present.  Defaults to "--no-140chars-check"
 export PUPPET_LINT_FAIL_ON_WARNINGS="true" # Set the puppet-lint option --fail-on-warnings
 UNSET_RUBY_ENV="enabled" # enabled or disabled. Required for Gitlab.

--- a/commit_hooks/puppet_lint_checks.sh
+++ b/commit_hooks/puppet_lint_checks.sh
@@ -11,7 +11,7 @@ module_dir="$3"
 syntax_errors=0
 error_msg="$(mktemp /tmp/error_msg_puppet-lint.XXXXX)"
 
-opts=${PUPPET_LINT_OPTIONS:-"--no-80chars-check"}
+opts=${PUPPET_LINT_OPTIONS:-"--no-140chars-check"}
 
 if [[ $module_dir ]]; then
     manifest_name="${manifest_path##*$module_dir}"


### PR DESCRIPTION
With help of bundler, required packages for pre-commit hooks are installed. 
Since now uses puppet-lint in version 2.0.0 which was released some weeks ago.