### PR TITLE
change where we check for puppet version

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -42,16 +42,16 @@ if [[ -f "$git_root/.git" ]]; then
     fi
 fi
 
-# Only puppet 3.2.1 - 3.8 support "--parser future" option.
-case $(puppet --version) in
-  4*) USE_PUPPET_FUTURE_PARSER="disabled" ;;
-esac
-
 # Decide if we want puppet-lint
 CHECK_PUPPET_LINT="enabled"
 if [[ -e ${subhook_root}/config.cfg ]] ; then
     source "${subhook_root}/config.cfg"
 fi
+
+# Only puppet 3.2.1 - 3.8 support "--parser future" option.
+case $(puppet --version) in
+  4*) USE_PUPPET_FUTURE_PARSER="disabled" ;;
+esac
 
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")


### PR DESCRIPTION
The check for the puppet version needs to go after sourcing the config files as this overrides the value with 

USE_PUPPET_FUTURE_PARSER="enabled"