### PR TITLE
Skip files under .git when checking all files

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -57,7 +57,7 @@ SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
 
 if [ $CHECK_ALL ]; then
-        files_to_check=$(find $git_root)
+        files_to_check=$(find $git_root -path $git_root/.git -prune -o -print)
 else
     files_to_check=$(git diff --cached --name-only --diff-filter=ACM)
 fi


### PR DESCRIPTION
The current 'find $gitroot' solution to check all files examines all the .git meta files as well.  These will never match, and on a large repo can be time consuming to skip.  This patch excludes them from the find output.