### PR TITLE
Improve home directory detection

### DIFF
--- a/pre-receive
+++ b/pre-receive
@@ -3,7 +3,7 @@
 # Puppet attempts to source ~/.puppet and will error if $HOME is not set
 if [[ -z $HOME ]]
 then
-  HOME="$(grep "${USER}:" /etc/passwd | awk -F ':' '{print $6}')"
+  HOME="$(getent passwd "${USER}" | awk -F ':' '{print $6}')"
   export HOME
 fi
 


### PR DESCRIPTION
Reading the home directory from /etc/passwd will fail if the user data is for example taken from ldap. The proper way to obtain this information is to query the nss via getent.