### PR TITLE
Fix r10k check

### DIFF
--- a/commit_hooks/r10k_syntax_check.sh
+++ b/commit_hooks/r10k_syntax_check.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 #
 # This script assumes you have installed r10k and will perform a syntax check on the Puppetfile if existing
+old_dir=$PWD
+pf_dir=$(dirname $1)
 
 echo "Performing a syntax check on the r10k Puppetfile:"
-PUPPETFILE="$1" r10k puppetfile check
+cd $pf_dir && r10k puppetfile check
 
 if [[ $? -ne 0 ]]
 then
-	exit 1
+  cd $old_dir
+  exit 1
 fi
+
+cd $old_dir
+exit 0


### PR DESCRIPTION
Latest R10k versions deprecated and removed the PUPPETFILE variable, making the r10k check fail. In the future there will be flags to provide that argument, but in the mean time, a dirty hack to allow the script to continue to work.

```
root@bitbucket /root> ./r10k_syntax_check.sh /root/my-control-repo/Puppetfile
Performing a syntax check on the r10k Puppetfile:
Syntax OK
```