### PR TITLE
r10k ignores PUPPETFILE variable

### DIFF
--- a/commit_hooks/r10k_syntax_check.sh
+++ b/commit_hooks/r10k_syntax_check.sh
@@ -3,7 +3,9 @@
 # This script assumes you have installed r10k and will perform a syntax check on the Puppetfile if existing
 
 echo "Performing a syntax check on the r10k Puppetfile:"
-PUPPETFILE="$1" r10k puppetfile check
+pushd "$1" >/dev/null
+r10k puppetfile check
+popd >/dev/null
 
 if [[ $? -ne 0 ]]
 then

--- a/pre-commit
+++ b/pre-commit
@@ -164,7 +164,7 @@ fi
 #r10k puppetfile syntax check
 if hash r10k >/dev/null 2>&1; then
   if [[ "$changedfile" = "Puppetfile" ]]; then
-        "${subhook_root}/r10k_syntax_check.sh"
+        "${subhook_root}/r10k_syntax_check.sh" "${git_root}/"
         RC=$?
         if [[ "$RC" -ne 0 ]]; then
                 failures=$((failures + 1))

--- a/pre-receive
+++ b/pre-receive
@@ -150,7 +150,7 @@ while read -r oldrev newrev refname; do
         #r10k puppetfile syntax check
         if hash r10k >/dev/null 2>&1; then
           if [ "$changedfile" = "Puppetfile" ]; then
-                ${subhook_root}/r10k_syntax_check.sh $tmptree/$changedfile
+                ${subhook_root}/r10k_syntax_check.sh "${tmptree}/"
                 RC=$?
                 if [ "$RC" -ne 0 ]; then
                        failures=`expr $failures + 1`


### PR DESCRIPTION
Hi,

I tried to change my Puppetfile and the commit hook failed with `No such file or directory @ rb_sysopen - /opt/puppetlabs/puppet/cache/puppet.git/Puppetfile.` where `/opt/puppetlabs/puppet/cache/puppet.git` is the pwd of the hook. It also showed a deprecation warning that PUPPETFILE variable is deprected. It seems that it ignores this Variable altogether. I did not find any commandline switch to forcefully give a puppetfile to check. Therefore I used pushd to change to the temporary workingdir and called r10k without parameter to use the default `$(pwd)/Puppetfile`.